### PR TITLE
Improvements

### DIFF
--- a/lib/Toc.coffee
+++ b/lib/Toc.coffee
@@ -8,7 +8,7 @@ class Toc
     @tab = "\t"
     @options =
       titleSize: 2  # titleSize
-      tabSpaces: @editor.getTabLength()  # tabSpaces 0 for hard-tab
+      tabSpaces: @_getTabLength() # tabSpaces 0 for hard-tab
       depthFrom: 1  # depthFrom
       depthTo: 6  # depthTo
       withLinks: 1  # withLinks
@@ -64,6 +64,11 @@ class Toc
 
   # ----------------------------------------------------------------------------
 
+  _getTabLength: () ->
+    try
+      tabLength = @editor.getTabLength()
+    catch error
+    return tabLength || 2
 
   _hasToc: () ->
     @___updateLines()

--- a/lib/Toc.coffee
+++ b/lib/Toc.coffee
@@ -30,10 +30,7 @@ class Toc
 
 
   create: ->
-    if @_hasToc()
-      @_deleteToc()
-      @editor.setTextInBufferRange [[@open,0], [@open,0]], @_createToc()
-    @editor.insertText @_createToc()
+    @update()
 
 
   update: ->
@@ -54,6 +51,7 @@ class Toc
       @_deleteToc()
       @editor.setTextInBufferRange [[@open,0], [@open,0]], @_createToc()
 
+
   toggle: ->
     if @_hasToc()
       @_deleteToc()
@@ -61,14 +59,15 @@ class Toc
       @editor.insertText @_createToc()
 
 
-
   # ----------------------------------------------------------------------------
+
 
   _getTabLength: () ->
     try
       tabLength = @editor.getTabLength()
     catch error
     return tabLength || 2
+
 
   _hasToc: () ->
     @___updateLines()

--- a/lib/markdown-toc.coffee
+++ b/lib/markdown-toc.coffee
@@ -3,6 +3,12 @@ Toc = require './Toc'
 module.exports =
 
   activate: (state) ->
+    atom.workspace.observeTextEditors (editor) =>
+      if editor.getRootScopeDescriptor().scopes[0] == 'text.md'
+        console.log 'YAY'
+        @toc = new Toc(editor)
+        @toc.update()
+
     atom.commands.add 'atom-workspace', 'markdown-toc:create': =>
         @toc = new Toc(atom.workspace.getActivePaneItem())
         @toc.create()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markdown-toc",
   "main": "./lib/markdown-toc",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Generate TOC (table of contents) of headlines from parsed markdown file",
   "activationHooks": [
     "text.md:root-scope-used"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "main": "./lib/markdown-toc",
   "version": "0.5.3",
   "description": "Generate TOC (table of contents) of headlines from parsed markdown file",
+  "activationHooks": [
+    "text.md:root-scope-used"
+  ],
   "activationCommands": {
     "atom-workspace": [
       "markdown-toc:toggle",


### PR DESCRIPTION
* Auto load on *.md files
* Handle error when `editor.getTabLength`is not defined
* Duplicate code removed